### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -28,7 +28,7 @@ class syntax_plugin_pageimage extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~PAGEIMAGE:.*?~~', $mode, 'plugin_pageimage');
     }
 
-    function handle($match, $state, $pos, Doku_Handler &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $image = trim(substr($match, 12, -2));     // strip markup & whitespace
         $image = cleanID($image);
         if(!$image) return false;
@@ -43,7 +43,7 @@ class syntax_plugin_pageimage extends DokuWiki_Syntax_Plugin {
     * @param array          $data      The data from the handler function
     * @return bool If rendering was successful.
     */
-    function render($mode, Doku_Renderer &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if ($data === false) return false;
 
         // XHTML output


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
