### PR TITLE
Also check for firstimage by default.

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -44,7 +44,7 @@ class helper_plugin_pageimage extends DokuWiki_Plugin {
         $width = null;
         $align = 'center';
         $ret = '';
-        $src = $this->getImageID($id);
+        $src = $this->getImageID($id,array('firstimage' => 1));
         
         if(!$src) {
             $src = $this->getConf('default_image');


### PR DESCRIPTION
The documentation at https://www.dokuwiki.org/plugin:pageimage mentions:

> There are 4 ways in which pageimage can find an image related to a page.

which includes the first image used in a page.  However, the code only check for the first image if the caller explicitly asks for it, which wasn't done.  FTR I noticed it because I'm heavily relying on that behavior for one of my setup.